### PR TITLE
Reduce NetVLAD++ RAM usage

### DIFF
--- a/Task1-ActionSpotting/TemporallyAwarePooling/src/main.py
+++ b/Task1-ActionSpotting/TemporallyAwarePooling/src/main.py
@@ -71,6 +71,10 @@ def main(args):
                 model_name=args.model_name,
                 max_epochs=args.max_epochs, evaluation_frequency=args.evaluation_frequency)
 
+    # Free up some RAM memory
+    del dataset_Train, dataset_Valid, dataset_Valid_metric, dataset_Test
+    del train_loader, val_loader, val_metric_loader
+
     # For the best model only
     checkpoint = torch.load(os.path.join("models", args.model_name, "model.pth.tar"))
     model.load_state_dict(checkpoint['state_dict'])


### PR DESCRIPTION
I made a super small change to the main.py of NetVLAD++ (TemporallyAwarePooling for action spotting), just deleting the train and validation datasets and dataloader (using del). This allows for the script to run using less than 60GB of RAM. Otherwise the process is killed (i.e. uses more than 60GB of RAM) just before testing (while creating the dataset_Test). This commit changes nothing in the training and testing logic, and the results are exactly the same with or without it.